### PR TITLE
Documentation: Fixed incorrect section title

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cd <SPIRE Installation Directory>
 ./spire-server run
 ```
 
-**SPIRE Server**
+**SPIRE Agent**
 
 ```bash
 cd <SPIRE Installation Directory>


### PR DESCRIPTION
There were two sections with name "SPIRE Server". The second one should have been "SPIRE Agent".